### PR TITLE
set ES version

### DIFF
--- a/mongoid-elasticsearch.gemspec
+++ b/mongoid-elasticsearch.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "mongoid", [">= 3.0", "< 6.0"]
-  spec.add_dependency "elasticsearch"
+  spec.add_dependency "elasticsearch", "~> 2.0.2"
   spec.add_dependency "ruby-progressbar"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
If you merge this I'll restart the Codeship tests to see if they pass.

2.0.2 is the latest in the Gem's 2.x release branch, and 2.x is the branch recommended for use with ES 2.x.